### PR TITLE
add config options to specify external blas/lapack libs

### DIFF
--- a/configure
+++ b/configure
@@ -4814,13 +4814,13 @@ fi
 # setup libs
 if test "x$blaslib" == "x"
 then
-  BLASLIB="-lmblas"
+  blaslib="-lmblas"
 fi
 if test "x$lapacklib" == "x"
 then
-  LAPACKLIB="-lmlapack"
+  lapacklib="-lmlapack"
 fi
-LIBS="$LIBS -lfac $LAPACKLIB $BLASLIB -lpthread"
+LIBS="$LIBS -lfac $lapacklib $blaslib -lpthread"
 
 fwithm=`echo "$FLIBS " | grep " -lm"`
 if test "x$fwithm" = "x"

--- a/configure.ac
+++ b/configure.ac
@@ -180,13 +180,13 @@ AC_ARG_WITH(lapacklib,
 # setup libs
 if test "x$blaslib" == "x"
 then
-  BLASLIB="-lmblas"
+  blaslib="-lmblas"
 fi
 if test "x$lapacklib" == "x"
 then
-  LAPACKLIB="-lmlapack"
+  lapacklib="-lmlapack"
 fi
-LIBS="$LIBS -lfac $LAPACKLIB $BLASLIB -lpthread"
+LIBS="$LIBS -lfac $lapacklib $blaslib -lpthread"
 
 fwithm=`echo "$FLIBS " | grep " -lm"`
 if test "x$fwithm" = "x"


### PR DESCRIPTION
new configure options --with-blaslib and --with-lapacklib to specify alternative blas and lapack libs, instead of using the one included in the fac.