### PR TITLE
rmatrix external region parallelization

### DIFF
--- a/configure
+++ b/configure
@@ -4666,7 +4666,7 @@ if test -n "$G77"
 then
   if test -z "$fopt"
   then
-    fopt="-Ofast"
+    fopt="-O2"
   fi
   if test -z "$fpic"
   then

--- a/configure.ac
+++ b/configure.ac
@@ -68,7 +68,7 @@ if test -n "$G77"
 then
   if test -z "$fopt"
   then 
-    fopt="-Ofast"
+    fopt="-O2"
   fi
   if test -z "$fpic"
   then

--- a/faclib/mpiutil.c
+++ b/faclib/mpiutil.c
@@ -164,9 +164,17 @@ long long CWidMPI() {
 }
 
 void ResetWidMPI(void) {
+#if USE_MPI == 2
+  if (!MPIReady()) {
+    printf("openmp not initialized\n");
+    Abort(1);
+  }
+#endif
   _cwid = -1;  
 #pragma omp parallel
+  {
   mpi.wid = 0;
+  }
 }
 
 void SetWidMPI(long long w) {

--- a/faclib/rmatrix.h
+++ b/faclib/rmatrix.h
@@ -43,8 +43,8 @@ typedef struct _RMATRIX_ {
   int nsym, isym, p, j;
   double **aij;
   double et0, *et, *ec, *ek, **w0, **w1;
-  double *rmatrix[3];
-  double z, energy;
+  double **rmatrix[3];
+  double z;
 } RMATRIX;
 
 typedef struct _DCFG_ {
@@ -57,6 +57,8 @@ typedef struct _DCFG_ {
   double rgailitis, degenerate, accuracy;
   int lrw, liw;
   RMATRIX *rmx;
+  int nr, mr;
+  double energy;
 } DCFG;
 
 int InitRMatrix(void);


### PR DESCRIPTION
external region parallelization for rmatrix. 
also found that with gfortran, -Ofast option breaks coulcc. to be safe, the fortran optimization uses -O2 now.