### PR TITLE
setup.py for virtual env and OSX.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -119,9 +119,13 @@ class MyCompiler(UnixCCompiler, object):
     def set_executables(self, **args):
         # basically, we ignore all the tool chain coming in
         if CC is not None:
+            if sys.platform == "linux" or sys.platform == "linux2":  # linux
+                shared_flag = ' -shared'
+            elif sys.platform == "darwin":  # OSX
+                shared_flag = ' -dynamiclib'
             super(self.__class__, self).set_executables(
                 compiler=CC, compiler_so=CC, linker_exe=CC,
-                linker_so=sysconfig.get_config_var('LDSHARED'))
+                linker_so=CC + shared_flag)
 
     def _fix_lib_args(self, libraries, library_dirs, runtime_library_dirs):
         # we need to have this method here, to avoid an endless

--- a/setup.py
+++ b/setup.py
@@ -123,6 +123,9 @@ class MyCompiler(UnixCCompiler, object):
                 shared_flag = ' -shared'
             elif sys.platform == "darwin":  # OSX
                 shared_flag = ' -dynamiclib'
+            else:
+                raise TypeError('Platform {} is not supported.'.format(
+                    sys.platform))
             super(self.__class__, self).set_executables(
                 compiler=CC, compiler_so=CC, linker_exe=CC,
                 linker_so=CC + shared_flag)


### PR DESCRIPTION
Thanks for digging the problem in setup.py (continued from #134)

>the test env needs to have pthread lib installed.

Actually, test env has pthread installed.

The recent standard for python users is to use virtual environments, which is isolated enviroment so that any installation of softwares in one environment has no effect on others.
The test env is also doing this.

It is beneficial for people working with multiple projects, but it makes the situation more complicated.
This is what I tried to tackle with in the previous PR.

In order to install PFAC into a virtual env, we need to compile C programs with the compiler in the virtual env rather than that in the native one.
The change in #135 is forced to use the native compiler.

I'd like to even use `linker_so=CC + ' -shared'` for linux, rather than `sysconfig.get_config_var('LDSHARED')` (which uses the native compiler).
The change I propose in this PR is to use the platform-dependent flag, 
(`-shared` for linux and ` -dynamiclib` for OSX).

Could you check if this is working also in OSX?
In order to download my branch, please do
```
git pull https://github.com/fujiisoup/fac.git setup_for_virtual_env:setup_for_virtual_env
```

closes #134
