### PR TITLE
tests with python3.6

### DIFF
--- a/ci/requirements-py36-openmp.yml
+++ b/ci/requirements-py36-openmp.yml
@@ -2,7 +2,7 @@ name: test_env
 channels:
   - conda-forge
 dependencies:
-  - python=2.7
+  - python=3.6
   - numpy
   - gcc_linux-64
   - gfortran_linux-64

--- a/ci/requirements-py36.yml
+++ b/ci/requirements-py36.yml
@@ -2,7 +2,7 @@ name: test_env
 channels:
   - conda-forge
 dependencies:
-  - python=2.7
+  - python=3.6
   - numpy
   - gcc_linux-64
   - gfortran_linux-64


### PR DESCRIPTION
It looks that I wrongly set up the testing configuration to always use python==2.7. Switched to python=3.6