### PR TITLE
Update mmalloc.c

### DIFF
--- a/faclib/mmalloc.c
+++ b/faclib/mmalloc.c
@@ -23,10 +23,10 @@
 #include <string.h>
 
 static size_t _tsize = 0;
-static double _msize = 0;
+static double _fmsize = 0;
 
 double dmsize() {
-  return _msize;
+  return _fmsize;
 }
 void *mmalloc(size_t size) {
   size_t *p = NULL;
@@ -41,7 +41,7 @@ void *mmalloc(size_t size) {
 #pragma omp atomic
   _tsize += size;
 #pragma omp atomic
-  _msize += size;
+  _fmsize += size;
   return &p[1];
 }
 


### PR DESCRIPTION
When compiling using MinGW _msize will collide with a function from the standard library. Renamed _msize to _fmsize as in FAC msize.